### PR TITLE
Make bag creation failed error more informative.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The admin settings form for this module requires the following:
    1. the URL of the Islandora Bagger REST endpoint. If you are running Islandora in the CLAW Vagrant, and Islandora Bagger on the host machine (i.e., same machine that is hosing the Vagrant), use `10.0.2.2` as your endpoint IP address instead of `localhost`.
    1. an option to add to the configuration file the email address of the user who requested the Bag be created. If checked, the user's email address will be added to the configuration file using the key `recipient_email`. In addition, if this option is checked, the message displayed to the user will indicate they will receive an email when their Bag is ready for download.
 1. If running in local mode, the absolute path to the directory on your Drupal server where Islandora Bagger is installed.
+    - This directory needs to be writable by the web server process user, e.g., www-data on most Linux systems.
 
 After you configure the admin setting, place the "Islandora Bagger Block" as you normally would any other block. You should restrict this block to the content types of your Islandora nodes, and to user roles who you want to be able to create Bags.
 

--- a/src/Plugin/Form/IslandoraBaggerForm.php
+++ b/src/Plugin/Form/IslandoraBaggerForm.php
@@ -67,7 +67,7 @@ class IslandoraBaggerForm extends FormBase {
 	  ['@file' => $config->get('islandora_bagger_default_config_file_path')]);
       $form_state->setErrorByName('submit', $message);
       \Drupal::logger('islandora_bagger_integration')->{'error'}($message);
-    }    
+    }
   }
 
   /**
@@ -120,11 +120,11 @@ class IslandoraBaggerForm extends FormBase {
 	@unlink($tmp_islandora_bagger_config_file_path);
       }
       else {
-	throw new ProcessFailedException($process);
+
         $messenger_level = 'addWarning';
         $logger_level = 'warning';
-        $message = $this->t('Request to create Bag for "@title" (node @nid) failed with return code @return_code.',
-          ['@title' => $title, '@nid' => $nid, '@return_code' => $return_code]
+        $message = $this->t('Request to create Bag for "@title" (node @nid) failed with return code @return_code and error text @error_text.',
+          ['@title' => $title, '@nid' => $nid, '@return_code' => $return_code, '@error_text' => $process->getErrorOutput()]
         );
       }
 


### PR DESCRIPTION
Just encountered a white screen when the www-data user can not write to the islandora_bagger/var/cache directory.

Adding a note that the directory needs to be writeable in the README and making bag creation failure display the error text rather than throwing an exception which is not caught and was resulting in a white screen.