### PR TITLE
Add support for JWT authentication 

### DIFF
--- a/islandora_bagger_integration.info.yml
+++ b/islandora_bagger_integration.info.yml
@@ -5,4 +5,5 @@ package: Islandora
 core: 8.x
 core_version_requirement: ^8 || ^9
 dependencies:
+  - getjwtonlogin
   - islandora

--- a/islandora_bagger_integration.install
+++ b/islandora_bagger_integration.install
@@ -60,6 +60,15 @@ function islandora_bagger_integration_requirements($phase) {
       }
     }
   }
+  elseif ($phase == 'update') {
+    if (!\Drupal::moduleHandler()->moduleExists('getjwtonlogin')) {
+      $requirements['islandora_bagger_integration_getjwtonlogin_enabled'] = [
+        'title' => t("Islandora Bagger Integration"),
+        'description' => t("Islandora Bagger now requires the <a href=\"https://drupal.org/project/getjwtonlogin\">Get JWT on Login</a> module."),
+        'severity' => REQUIREMENT_ERROR,
+      ];
+    }
+  }
   return $requirements;
 }
 

--- a/src/Plugin/Form/IslandoraBaggerForm.php
+++ b/src/Plugin/Form/IslandoraBaggerForm.php
@@ -7,6 +7,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessFailedException;
+use Drupal\jwt\Authentication\Provider\JwtAuth;
 
 /**
  * Implements a form.
@@ -99,7 +100,14 @@ class IslandoraBaggerForm extends FormBase {
       $islandora_bagger_config_file_path = $tmp_islandora_bagger_config_file_path;
 
       $bagger_directory = $config->get('islandora_bagger_local_bagger_directory');
-      $bagger_cmd = ['./bin/console', 'app:islandora_bagger:create_bag', '--settings=' . $islandora_bagger_config_file_path, '--node=' . $nid];
+
+      /**
+       * @var JwtAuth $jwt
+       */
+      $jwt = \Drupal::service('jwt.authentication.jwt');
+      $bagger_cmd = ['./bin/console', 'app:islandora_bagger:create_bag', '--settings=' . $islandora_bagger_config_file_path, '--node=' . $nid,
+       '--token=' . $jwt->generateToken()];
+
 
       $process = new Process($bagger_cmd);
       $process->setWorkingDirectory($bagger_directory);


### PR DESCRIPTION
issue: https://github.com/mjordan/islandora_bagger/issues/25

Related PR: https://github.com/mjordan/islandora_bagger/pull/77

This PR does the following:

- Adds [Get JWT On Login](https://drupal.org/project/getjwtonlogin) to the module dependencies.
- Adds the current user's JWT token as a parameter to islandora-bagger in local mode.

As mentioned in the related PR, if no token is supplied, one will be requested via POST using the credentials in the config settings.

There is a check in the requirements hook so updatedb will print an error if the getjwtonlogin module is not enabled.

### To test

All existing workflows should work as before, with no new configuration settings needed.

The user who initiates the bag creation must have all the required permissions to retrieve e.g. related media. Presumably if the user is looking at the object this is already the case but there could be cases where it is not.